### PR TITLE
add metric rabbitmq_exchange_messages_deliver_get_total

### DIFF
--- a/src/prometheus_rabbitmq_exporter_config.erl
+++ b/src/prometheus_rabbitmq_exporter_config.erl
@@ -24,6 +24,7 @@
                                          messages_delivered_no_ack_total,
                                          messages_get_total,
                                          messages_get_no_ack_total,
+                                         messages_deliver_get_total,
                                          messages_redelivered_total,
                                          messages_returned_total]).
 -define(DEFAULT_CONFIG, [{path, ?DEFAULT_PATH},


### PR DESCRIPTION
Sum of *messages_delivered_total, *messages_delivered_no_ack_total, *messages_get_total and *messages_get_no_ack_total.
Same as rabbitmq_queue_messages_deliver_get_total, except per exchange.