### PR TITLE
Assorted build system and plugin metadata improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,7 @@
 FROM rabbitmq:3.7-management
 MAINTAINER  Ilya Khaprov <i.khaprov@gmail.com>
 
-# prometheus exporter plugin
-ADD ["plugins/accept-*", \
-     "plugins/prometheus-*", \
-     "plugins/prometheus_httpd-*",\
-     "plugins/prometheus_cowboy-*", \
-     "plugins/prometheus_process_collector-*", \
-     "plugins/prometheus_rabbitmq_exporter-*", \
-     "/usr/lib/rabbitmq/lib/rabbitmq_server-${RABBITMQ_VERSION}/plugins/"]
-RUN chmod a+r /usr/lib/rabbitmq/lib/rabbitmq_server-${RABBITMQ_VERSION}/plugins/prometheus*.ez /usr/lib/rabbitmq/lib/rabbitmq_server-${RABBITMQ_VERSION}/plugins/accept*.ez \
-    && rabbitmq-plugins enable --offline prometheus accept prometheus_rabbitmq_exporter prometheus_process_collector prometheus_httpd prometheus_cowboy \
-    && chmod -R 777 /etc/rabbitmq
+# Copy the plugin and its dependencies
+COPY "plugins/*.ez" "/usr/lib/rabbitmq/lib/rabbitmq_server-${RABBITMQ_VERSION}/plugins/"
+RUN chmod a+r ""/usr/lib/rabbitmq/lib/rabbitmq_server-${RABBITMQ_VERSION}/plugins/prometheus*.ez" ""/usr/lib/rabbitmq/lib/rabbitmq_server-${RABBITMQ_VERSION}/plugins/accept*.ez" \
+    && rabbitmq-plugins enable --offline prometheus_rabbitmq_exporter

--- a/Dockerfile.pure
+++ b/Dockerfile.pure
@@ -1,13 +1,7 @@
 FROM rabbitmq:3.7-management
 MAINTAINER  Ilya Khaprov <i.khaprov@gmail.com>
 
-# prometheus exporter plugin
-ADD ["plugins/accept-*", \
-     "plugins/prometheus-*", \
-     "plugins/prometheus_httpd-*", \
-     "plugins/prometheus_cowboy-*", \
-     "plugins/prometheus_rabbitmq_exporter-*", \
-     "/usr/lib/rabbitmq/lib/rabbitmq_server-${RABBITMQ_VERSION}/plugins/"]
+# Copy the plugin and its dependencies
+COPY "plugins/*.ez" "/usr/lib/rabbitmq/lib/rabbitmq_server-${RABBITMQ_VERSION}/plugins/"
 RUN chmod a+r /usr/lib/rabbitmq/lib/rabbitmq_server-${RABBITMQ_VERSION}/plugins/prometheus*.ez /usr/lib/rabbitmq/lib/rabbitmq_server-${RABBITMQ_VERSION}/plugins/accept*.ez \
-    && rabbitmq-plugins enable --offline accept prometheus prometheus_rabbitmq_exporter prometheus_httpd prometheus_cowboy \
-    && chmod -R 777 /etc/rabbitmq
+    && rabbitmq-plugins enable --offline prometheus_rabbitmq_exporter

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,4 @@
 PROJECT = prometheus_rabbitmq_exporter
-PROJECT_DESCRIPTION = Prometheus.io exporter as a RabbitMQ Managment Plugin plugin
-
-define PROJECT_APP_EXTRA_KEYS
-	{broker_version_requirements, []}
-endef
 
 dep_prometheus = hex 3.5.1
 dep_prometheus_process_collector = hex 1.3.1

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
 PROJECT = prometheus_rabbitmq_exporter
 PROJECT_DESCRIPTION = Prometheus.io exporter as a RabbitMQ Managment Plugin plugin
-#PROJECT_MOD = prometheus_rabbitmq_exporter
 
-DEPS = rabbitmq_management prometheus prometheus_httpd accept \
-	prometheus_process_collector prometheus_cowboy
+define PROJECT_APP_EXTRA_KEYS
+	{broker_version_requirements, []}
+endef
+
 dep_prometheus = hex 3.5.1
 dep_prometheus_process_collector = hex 1.3.1
 dep_prometheus_httpd = hex 2.1.8
 dep_accept = hex 0.3.3
 dep_prometheus_cowboy = hex 0.1.4
+
+DEPS = rabbit_common rabbit rabbitmq_management prometheus prometheus_httpd accept \
+	prometheus_process_collector prometheus_cowboy
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
@@ -19,25 +23,25 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
 ERLANG_MK_COMMIT = rabbitmq-tmp
 
+include rabbitmq-components.mk
+include erlang.mk
+
 .PHONY: docker_build docker_push docker_latest docker_latest_pure
 
 docker_build:
-	docker build -t deadtrickster/rabbitmq_prometheus\:3.7.2 .
+	docker build -t deadtrickster/rabbitmq_prometheus\:3.7.7 .
 	docker build -t deadtrickster/rabbitmq_prometheus\:latest .
-	docker build -t deadtrickster/rabbitmq_prometheus\:3.7.2-pure -f Dockerfile.pure  .
+	docker build -t deadtrickster/rabbitmq_prometheus\:3.7.7-pure -f Dockerfile.pure  .
 	docker build -t deadtrickster/rabbitmq_prometheus\:latest-pure -f Dockerfile.pure  .
 
 docker_push:
-	docker push deadtrickster/rabbitmq_prometheus\:3.7.2
+	docker push deadtrickster/rabbitmq_prometheus\:3.7.7
 	docker push deadtrickster/rabbitmq_prometheus\:latest
-	docker push deadtrickster/rabbitmq_prometheus\:3.7.2-pure
+	docker push deadtrickster/rabbitmq_prometheus\:3.7.7-pure
 	docker push deadtrickster/rabbitmq_prometheus\:latest-pure
 
 docker_latest:
 	-docker run -p15672\:15672 deadtrickster/rabbitmq_prometheus\:latest
 
 docker_pure:
-	-docker run -p15672\:15672 deadtrickster/rabbitmq_prometheus\:latest-pure 
-
-include rabbitmq-components.mk
-include erlang.mk
+	-docker run -p15672\:15672 deadtrickster/rabbitmq_prometheus\:latest-pure

--- a/erlang.mk
+++ b/erlang.mk
@@ -18,7 +18,7 @@ ERLANG_MK_FILENAME := $(realpath $(lastword $(MAKEFILE_LIST)))
 export ERLANG_MK_FILENAME
 
 ERLANG_MK_VERSION = 2.0.0-pre.2-311-gb20df2d
-ERLANG_MK_WITHOUT = 
+ERLANG_MK_WITHOUT = plugins/proper
 
 # Make 3.81 and 3.82 are deprecated.
 
@@ -4876,6 +4876,37 @@ ERLANG_MK_RECURSIVE_REL_DEPS_LIST = $(ERLANG_MK_TMP)/recursive-rel-deps-list.log
 ERLANG_MK_RECURSIVE_TEST_DEPS_LIST = $(ERLANG_MK_TMP)/recursive-test-deps-list.log
 ERLANG_MK_RECURSIVE_SHELL_DEPS_LIST = $(ERLANG_MK_TMP)/recursive-shell-deps-list.log
 
+# Copyright (c) 2015-2016, Loïc Hoguin <essen@ninenines.eu>
+# This file is part of erlang.mk and subject to the terms of the ISC License.
+
+# Verbosity.
+
+proto_verbose_0 = @echo " PROTO " $(filter %.proto,$(?F));
+proto_verbose = $(proto_verbose_$(V))
+
+# Core targets.
+
+define compile_proto
+	$(verbose) mkdir -p ebin/ include/
+	$(proto_verbose) $(call erlang,$(call compile_proto.erl,$(1)))
+	$(proto_verbose) erlc +debug_info -o ebin/ ebin/*.erl
+	$(verbose) rm ebin/*.erl
+endef
+
+define compile_proto.erl
+	[begin
+		protobuffs_compile:generate_source(F,
+			[{output_include_dir, "./include"},
+				{output_src_dir, "./ebin"}])
+	end || F <- string:tokens("$(1)", " ")],
+	halt().
+endef
+
+ifneq ($(wildcard src/),)
+ebin/$(PROJECT).app:: $(sort $(call core_find,src/,*.proto))
+	$(if $(strip $?),$(call compile_proto,$?))
+endif
+
 # Copyright (c) 2013-2016, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
@@ -6502,60 +6533,6 @@ apps-eunit:
 	$(verbose) eunit_retcode=0 ; for app in $(ALL_APPS_DIRS); do $(MAKE) -C $$app eunit IS_APP=1; \
 		[ $$? -ne 0 ] && eunit_retcode=1 ; done ; \
 		exit $$eunit_retcode
-endif
-endif
-
-# Copyright (c) 2015-2017, Loïc Hoguin <essen@ninenines.eu>
-# This file is part of erlang.mk and subject to the terms of the ISC License.
-
-ifeq ($(filter proper,$(DEPS) $(TEST_DEPS)),proper)
-.PHONY: proper
-
-# Targets.
-
-tests:: proper
-
-define proper_check.erl
-	code:add_pathsa(["$(call core_native_path,$(CURDIR)/ebin)", "$(call core_native_path,$(DEPS_DIR)/*/ebin)"]),
-	Module = fun(M) ->
-		[true] =:= lists:usort([
-			case atom_to_list(F) of
-				"prop_" ++ _ ->
-					io:format("Testing ~p:~p/0~n", [M, F]),
-					proper:quickcheck(M:F(), nocolors);
-				_ ->
-					true
-			end
-		|| {F, 0} <- M:module_info(exports)])
-	end,
-	try
-		case $(1) of
-			all -> [true] =:= lists:usort([Module(M) || M <- [$(call comma_list,$(3))]]);
-			module -> Module($(2));
-			function -> proper:quickcheck($(2), nocolors)
-		end
-	of
-		true -> halt(0);
-		_ -> halt(1)
-	catch error:undef ->
-		io:format("Undefined property or module?~n~p~n", [erlang:get_stacktrace()]),
-		halt(0)
-	end.
-endef
-
-ifdef t
-ifeq (,$(findstring :,$(t)))
-proper: test-build
-	$(verbose) $(call erlang,$(call proper_check.erl,module,$(t)))
-else
-proper: test-build
-	$(verbose) echo Testing $(t)/0
-	$(verbose) $(call erlang,$(call proper_check.erl,function,$(t)()))
-endif
-else
-proper: test-build
-	$(eval MODULES := $(patsubst %,'%',$(sort $(notdir $(basename $(wildcard ebin/*.beam))))))
-	$(gen_verbose) $(call erlang,$(call proper_check.erl,all,undefined,$(MODULES)))
 endif
 endif
 

--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -111,13 +111,13 @@ dep_rabbitmq_public_umbrella          = git_rmq rabbitmq-public-umbrella $(curre
 # all projects use the same versions. It avoids conflicts and makes it
 # possible to work with rabbitmq-public-umbrella.
 
-dep_cowboy = hex 2.3.0
-dep_cowlib = hex 2.2.1
-dep_jsx = hex 2.9.0
-dep_lager = hex 3.6.1
+dep_cowboy = hex 2.2.2
+dep_cowlib = hex 2.1.0
+dep_jsx = hex 2.8.2
+dep_lager = hex 3.6.3
 dep_ranch = hex 1.5.0
 dep_ranch_proxy_protocol = hex 1.5.0
-dep_recon = hex 2.3.4
+dep_recon = hex 2.3.2
 
 dep_sockjs = git https://github.com/rabbitmq/sockjs-erlang.git 405990ea62353d98d36dbf5e1e64942d9b0a1daf
 
@@ -203,7 +203,7 @@ export current_rmq_ref
 
 ifeq ($(origin base_rmq_ref),undefined)
 ifneq ($(wildcard .git),)
-possible_base_rmq_ref := master
+possible_base_rmq_ref := v3.7.x
 ifeq ($(possible_base_rmq_ref),$(current_rmq_ref))
 base_rmq_ref := $(current_rmq_ref)
 else

--- a/src/prometheus_rabbitmq_exporter.app.src
+++ b/src/prometheus_rabbitmq_exporter.app.src
@@ -1,6 +1,8 @@
 {application, prometheus_rabbitmq_exporter,
  [{description, "RabbitMQ Prometheus.io metrics exporter"},
-  {vsn, "v3.7.2.3"},
+  %% 3.7.2 or newer 3.7.x
+  {broker_version_requirements, ["3.7.2"]},
+  {vsn, "3.7.2.3"},
   {modules, []},
   {registered, []},
   {env, []},


### PR DESCRIPTION
This started as a small PR that only added `rabbit` as a dependency but ended up being a bunch of build system improvements that I had to make to build the plugin from source against the tip of RabbitMQ `3.7.x`.