### PR TITLE
Add node metrics provided by management API

### DIFF
--- a/src/collectors/prometheus_rabbitmq_nodes_collector.erl
+++ b/src/collectors/prometheus_rabbitmq_nodes_collector.erl
@@ -13,9 +13,66 @@
                                    counter_metric/1,
                                    counter_metric/2,
                                    untyped_metric/1,
-                                   untyped_metric/2]).
+                                   untyped_metric/2,
+                                   boolean_metric/2]).
 
 -include("prometheus_rabbitmq_exporter.hrl").
+
+-define(METRIC_NAME_PREFIX, "rabbitmq_node_").
+
+-define(METRICS, [ {partitions, gauge, "Partitions detected in the cluster.",
+                    fun(Node) ->
+                            length(proplists:get_value(partitions, Node, []))
+                    end},
+                   {fd_total, gauge, "File descriptors available."},
+                   {sockets_total, gauge, "Sockets available."},
+                   {mem_limit, gauge, "Memory usage high watermark."},
+                   {mem_alarm, boolean, "Set to 1 if a memory alarm is in effect in the node."},
+                   {disk_free_limit, gauge, "Free disk space low watermark."},
+                   {disk_free_alarm, boolean, "Set to 1 if a memory alarm is in effect in the node."},
+                   {proc_total, gauge, "Erlang processes limit."},
+                   {uptime, counter, "Time in milliseconds since node start."},
+                   {run_queue, gauge, "Runtime run queue."},
+                   {processors, gauge, "Logical processors."},
+                   {net_ticktime, gauge, "Network tick time between pairs of Erlang nodes."},
+                   {mem_used, gauge, "Memory used in bytes"},
+                   {fd_used, gauge, "File descriptors used."},
+                   {sockets_used, gauge, "Sockets used."},
+                   {proc_used, gauge, "Erlang processes used."},
+                   {disk_free, gauge, "Disk free in bytes"},
+                   {gc_num, counter, "GC runs."},
+                   {gc_bytes_reclaimed, counter, "Bytes reclaimed by GC."},
+                   {context_switches, counter, "Context switches since node start."},
+                   {io_read_count, counter, "Read operations since node start."},
+                   {io_read_bytes, counter, "Bytes read since node start."},
+                   {io_read_avg_time, gauge, "Average time of read operations."},
+                   {io_write_count, counter, "Write operations since node start."},
+                   {io_write_bytes, counter, "Bytes written since node start."},
+                   {io_write_avg_time, gauge, "Average time of write operations."},
+                   {io_sync_count, counter, "Sync operations sync node start."},
+                   {io_sync_avg_time, gauge, "Average time of sync operations."},
+                   {io_seek_count, counter, "Seek operations since node start."},
+                   {io_seek_avg_time, gauge, "Average time of seek operations."},
+                   {io_reopen_count, counter, "Times files have been reopened by the file handle cache."},
+                   {mnesia_ram_tx_count, counter, "Mnesia transactions in RAM since node start."},
+                   {mnesia_disk_tx_count, counter, "Mnesia transactions in disk since node start."},
+                   {msg_store_read_count, counter, "Read operations in the message store since node start."},
+                   {msg_store_write_count, counter, "Write operations in the message store since node start."},
+                   {queue_index_journal_write_count, counter, "Write operations in the queue index journal since node start."},
+                   {queue_index_write_count, counter, "Queue index write operations since node start."},
+                   {queue_index_read_count, counter, "Queue index read operations since node start."},
+                   {io_file_handle_open_attempt_count, counter, "File descriptor open attempts."},
+                   {io_file_handle_open_attempt_avg_time, gauge, "Average time of file descriptor open attempts."},
+                   {metrics_gc_queue_length_channel_closed, gauge, "Message queue length of GC process for channel metrics", get_metrics_gc_queue_length(channel_closed)},
+                   {metrics_gc_queue_length_connection_closed, gauge, "Message queue length of GC process for connection metrics", get_metrics_gc_queue_length(connection_closed)},
+                   {metrics_gc_queue_length_consumer_deleted, gauge, "Message queue length of GC process for consumer metrics", get_metrics_gc_queue_length(consumer_deleted)},
+                   {metrics_gc_queue_length_exchange_deleted, gauge, "Message queue length of GC process for exchange metrics", get_metrics_gc_queue_length(exchange_deleted)},
+                   {metrics_gc_queue_length_node_node_deleted, gauge, "Message queue length of GC process for node-node metrics", get_metrics_gc_queue_length(node_deleted)},
+                   {metrics_gc_queue_length_queue_deleted, gauge, "Message queue length of GC process for queue metrics", get_metrics_gc_queue_length(queue_deleted)},
+                   {metrics_gc_queue_length_vhost_deleted, gauge, "Message queue length of GC process for vhost metrics", get_metrics_gc_queue_length(vhost_deleted)},
+                   {metrics_gc_queue_length_channel_consumer_deleted, gauge, "Message queue length of GC process for consumer metrics", get_metrics_gc_queue_length(channel_consumer_deleted)}
+                 ]).
+
 -behaviour(prometheus_collector).
 
 %%====================================================================
@@ -33,10 +90,33 @@ deregister_cleanup(_) -> ok.
 collect_mf(_Registry, Callback) ->
   Nodes = all_nodes_raw(),
   Callback(create_untyped(rabbitmq_node_up, "Node runnning status", Nodes)),
-  ok.
+  case prometheus_rabbitmq_exporter_config:detailed_node_stat_enabled() of
+      all ->
+          collect_detailed_stats(Callback, Nodes);
+      local ->
+          [Node] = lists:filter(fun(N) ->
+                                        node() == proplists:get_value(name, N)
+                                end, Nodes),
+          collect_detailed_stats(Callback, [Node]);
+      _ ->
+          ok
+  end.
 
 collect_metrics(rabbitmq_node_up, Nodes) ->
-  [untyped_metric(labels(Node), node_running(Node)) || Node <- Nodes].
+    [untyped_metric(labels(Node), node_running(Node)) || Node <- Nodes];
+collect_metrics(_, {Type, Fun, Nodes}) ->
+    [metric(Type, labels(Node), Fun(Node)) || Node <- Nodes].
+
+metric(_, _, undefined) ->
+    undefined;
+metric(counter, Labels, Value) ->
+    counter_metric(Labels, Value);
+metric(gauge, Labels, Value) ->
+    gauge_metric(Labels, Value);
+metric(untyped, Labels, Value) ->
+    untyped_metric(Labels, Value);
+metric(boolean, Labels, Value) ->
+    boolean_metric(Labels, Value).
 
 %%====================================================================
 %% Private Parts
@@ -71,3 +151,25 @@ node_running(Node) ->
 
 create_untyped(Name, Help, Data) ->
   create_mf(Name, Help, untyped, ?MODULE, Data).
+
+collect_detailed_stats(Callback, Nodes) ->
+    Augmented = rabbit_mgmt_db:augment_nodes(Nodes, ?NO_RANGE),
+    [collect_detailed_stats(Callback, Augmented, Metric) || Metric <- ?METRICS],
+    ok.
+
+collect_detailed_stats(Callback, Augmented, {Key, Type, Help}) ->
+    Callback(create_mf(?METRIC_NAME(Key), Help, Type, ?MODULE,
+                       {Type, fun(Node) ->
+                                      proplists:get_value(Key, Node, undefined)
+                              end,
+                        Augmented}));
+collect_detailed_stats(Callback, Augmented, {Key, Type, Help, Fun}) ->
+    Callback(create_mf(?METRIC_NAME(Key), Help, Type, ?MODULE,
+                       {Type, Fun, Augmented})).
+
+get_metrics_gc_queue_length(Tag) ->
+    fun(Node) ->
+            proplists:get_value(Tag,
+                                proplists:get_value(metrics_gc_queue_length, Node, []),
+                                undefined)
+    end.

--- a/src/prometheus_rabbitmq_exporter_config.erl
+++ b/src/prometheus_rabbitmq_exporter_config.erl
@@ -5,7 +5,8 @@
          queue_messages_stat/0,
          exchange_messages_stat/0,
          memory_stat_enabled/0,
-         connections_total_enabled/0]).
+         connections_total_enabled/0,
+         detailed_node_stat_enabled/0]).
 
 -define(DEFAULT_PATH, "/metrics").
 -define(DEFAULT_USE_MGMT_AUTH, false).
@@ -31,6 +32,7 @@
                                          messages_returned_total]).
 -define(DEFAULT_MEMORY_STAT_ENABLED, false).
 -define(DEFAULT_CONNECTIONS_TOTAL_ENABLED, false).
+-define(DEFAULT_DETAILED_NODE_STAT_ENABLED, none).
 
 config() ->
   application:get_env(prometheus, rabbitmq_exporter, []).
@@ -59,3 +61,6 @@ connections_total_enabled() ->
   Config = config(),
   proplists:get_value(connections_total_enabled, Config, ?DEFAULT_CONNECTIONS_TOTAL_ENABLED).
 
+detailed_node_stat_enabled() ->
+    Config = config(),
+    proplists:get_value(detailed_node_stat_enabled, Config, ?DEFAULT_DETAILED_NODE_STAT_ENABLED).


### PR DESCRIPTION
Some users (see #37 and #13) requested node metrics such as file descriptors, sockets, memory and disk alarms to be available in Prometheus.

All these are accessible through `rabbit_mgmt_db:augment_nodes`, and this PR allows them to be displayed as part of `prometheus_rabbitmq_nodes_collector` data. Detailed node stats are disabled by default, and can be configured to `local` or `all`. `local` will provide the detailed stats from the node that is being queried and `all` for the whole cluster. The last setting is only recommended if metrics are being pulled from a single node. When all nodes in the cluster are configured as prometheus targets, `local` should be used.

 ```
{prometheus, [{rabbitmq_exporter, [{detailed_node_stat_enabled, local}]}]}
```

Memory and disk alarms can be configured in prometheus as `rules`, such as:
```
groups:
- name: example
  rules:
  - alert: NodeMemAlarm
    expr: rabbitmq_node_mem_used > rabbitmq_node_mem_limit
    labels:
     severity: page
    annotations:
     summary: Memory alarm
```
`mem_alarm` and `disk_free_alarm` can be used instead, which display a boolean indicating whether an alarm is active in the cluster.

This PR might also reduce the need for `prometheus_process_collector` for monitoring, or provide an alternative in some situations, which can be problematic because of the inclusion of NIFS (see issue #12).  

Closes `37` and `13`.

Example of scrape:
```
# TYPE rabbitmq_node_up untyped
# HELP rabbitmq_node_up Node runnning status
rabbitmq_node_up{name="rabbit2@mars",type="disc"} 1
rabbitmq_node_up{name="rabbit@mars",type="disc"} 1
# TYPE rabbitmq_node_partitions gauge
# HELP rabbitmq_node_partitions Partitions detected in the cluster.
rabbitmq_node_partitions{name="rabbit@mars",type="disc"} 0
# TYPE rabbitmq_node_fd_total gauge
# HELP rabbitmq_node_fd_total File descriptors available.
# TYPE rabbitmq_node_sockets_total gauge
# HELP rabbitmq_node_sockets_total Sockets available.
# TYPE rabbitmq_node_mem_limit gauge
# HELP rabbitmq_node_mem_limit Memory usage high watermark.
# TYPE rabbitmq_node_mem_alarm untyped
# HELP rabbitmq_node_mem_alarm Set to 1 if a memory alarm is in effect in the node.
# TYPE rabbitmq_node_disk_free_limit gauge
# HELP rabbitmq_node_disk_free_limit Free disk space low watermark.
# TYPE rabbitmq_node_disk_free_alarm untyped
# HELP rabbitmq_node_disk_free_alarm Set to 1 if a memory alarm is in effect in the node.
# TYPE rabbitmq_node_proc_total gauge
# HELP rabbitmq_node_proc_total Erlang processes limit.
# TYPE rabbitmq_node_uptime counter
# HELP rabbitmq_node_uptime Time in milliseconds since node start.
# TYPE rabbitmq_node_run_queue gauge
# HELP rabbitmq_node_run_queue Runtime run queue.
# TYPE rabbitmq_node_processors gauge
# HELP rabbitmq_node_processors Logical processors.
# TYPE rabbitmq_node_net_ticktime gauge
# HELP rabbitmq_node_net_ticktime Network tick time between pairs of Erlang nodes.
# TYPE rabbitmq_node_mem_used gauge
# HELP rabbitmq_node_mem_used Memory used in bytes
# TYPE rabbitmq_node_fd_used gauge
# HELP rabbitmq_node_fd_used File descriptors used.
# TYPE rabbitmq_node_sockets_used gauge
# HELP rabbitmq_node_sockets_used Sockets used.
# TYPE rabbitmq_node_proc_used gauge
# HELP rabbitmq_node_proc_used Erlang processes used.
# TYPE rabbitmq_node_disk_free gauge
# HELP rabbitmq_node_disk_free Disk free in bytes
# TYPE rabbitmq_node_gc_num counter
# HELP rabbitmq_node_gc_num GC runs.
# TYPE rabbitmq_node_gc_bytes_reclaimed counter
# HELP rabbitmq_node_gc_bytes_reclaimed Bytes reclaimed by GC.
# TYPE rabbitmq_node_context_switches counter
# HELP rabbitmq_node_context_switches Context switches since node start.
# TYPE rabbitmq_node_io_read_count counter
# HELP rabbitmq_node_io_read_count Read operations since node start.
# TYPE rabbitmq_node_io_read_bytes counter
# HELP rabbitmq_node_io_read_bytes Bytes read since node start.
# TYPE rabbitmq_node_io_read_avg_time gauge
# HELP rabbitmq_node_io_read_avg_time Average time of read operations.
# TYPE rabbitmq_node_io_write_count counter
# HELP rabbitmq_node_io_write_count Write operations since node start.
# TYPE rabbitmq_node_io_write_bytes counter
# HELP rabbitmq_node_io_write_bytes Bytes written since node start.
# TYPE rabbitmq_node_io_write_avg_time gauge
# HELP rabbitmq_node_io_write_avg_time Average time of write operations.
# TYPE rabbitmq_node_io_sync_count counter
# HELP rabbitmq_node_io_sync_count Sync operations sync node start.
# TYPE rabbitmq_node_io_sync_avg_time gauge
# HELP rabbitmq_node_io_sync_avg_time Average time of sync operations.
# TYPE rabbitmq_node_io_seek_count counter
# HELP rabbitmq_node_io_seek_count Seek operations since node start.
# TYPE rabbitmq_node_io_seek_avg_time gauge
# HELP rabbitmq_node_io_seek_avg_time Average time of seek operations.
# TYPE rabbitmq_node_io_reopen_count counter
# HELP rabbitmq_node_io_reopen_count Times files have been reopened by the file handle cache.
# TYPE rabbitmq_node_mnesia_ram_tx_count counter
# HELP rabbitmq_node_mnesia_ram_tx_count Mnesia transactions in RAM since node start.
# TYPE rabbitmq_node_mnesia_disk_tx_count counter
# HELP rabbitmq_node_mnesia_disk_tx_count Mnesia transactions in disk since node start.
# TYPE rabbitmq_node_msg_store_read_count counter
# HELP rabbitmq_node_msg_store_read_count Read operations in the message store since node start.
# TYPE rabbitmq_node_msg_store_write_count counter
# HELP rabbitmq_node_msg_store_write_count Write operations in the message store since node start.
# TYPE rabbitmq_node_queue_index_journal_write_count counter
# HELP rabbitmq_node_queue_index_journal_write_count Write operations in the queue index journal since node start.
# TYPE rabbitmq_node_queue_index_write_count counter
# HELP rabbitmq_node_queue_index_write_count Queue index write operations since node start.
# TYPE rabbitmq_node_queue_index_read_count counter
# HELP rabbitmq_node_queue_index_read_count Queue index read operations since node start.
# TYPE rabbitmq_node_io_file_handle_open_attempt_count counter
# HELP rabbitmq_node_io_file_handle_open_attempt_count File descriptor open attempts.
# TYPE rabbitmq_node_io_file_handle_open_attempt_avg_time gauge
# HELP rabbitmq_node_io_file_handle_open_attempt_avg_time Average time of file descriptor open attempts.
# TYPE rabbitmq_node_metrics_gc_queue_length_channel_closed gauge
# HELP rabbitmq_node_metrics_gc_queue_length_channel_closed Message queue length of GC process for channel metrics
rabbitmq_node_metrics_gc_queue_length_channel_closed{name="rabbit@mars",type="disc"} 0
# TYPE rabbitmq_node_metrics_gc_queue_length_connection_closed gauge
# HELP rabbitmq_node_metrics_gc_queue_length_connection_closed Message queue length of GC process for connection metrics
rabbitmq_node_metrics_gc_queue_length_connection_closed{name="rabbit@mars",type="disc"} 0
# TYPE rabbitmq_node_metrics_gc_queue_length_consumer_deleted gauge
# HELP rabbitmq_node_metrics_gc_queue_length_consumer_deleted Message queue length of GC process for consumer metrics
rabbitmq_node_metrics_gc_queue_length_consumer_deleted{name="rabbit@mars",type="disc"} 0
# TYPE rabbitmq_node_metrics_gc_queue_length_exchange_deleted gauge
# HELP rabbitmq_node_metrics_gc_queue_length_exchange_deleted Message queue length of GC process for exchange metrics
rabbitmq_node_metrics_gc_queue_length_exchange_deleted{name="rabbit@mars",type="disc"} 0
# TYPE rabbitmq_node_metrics_gc_queue_length_node_node_deleted gauge
# HELP rabbitmq_node_metrics_gc_queue_length_node_node_deleted Message queue length of GC process for node-node metrics
# TYPE rabbitmq_node_metrics_gc_queue_length_queue_deleted gauge
# HELP rabbitmq_node_metrics_gc_queue_length_queue_deleted Message queue length of GC process for queue metrics
rabbitmq_node_metrics_gc_queue_length_queue_deleted{name="rabbit@mars",type="disc"} 0
# TYPE rabbitmq_node_metrics_gc_queue_length_vhost_deleted gauge
# HELP rabbitmq_node_metrics_gc_queue_length_vhost_deleted Message queue length of GC process for vhost metrics
rabbitmq_node_metrics_gc_queue_length_vhost_deleted{name="rabbit@mars",type="disc"} 0
# TYPE rabbitmq_node_metrics_gc_queue_length_channel_consumer_deleted gauge
# HELP rabbitmq_node_metrics_gc_queue_length_channel_consumer_deleted Message queue length of GC process for consumer metrics
rabbitmq_node_metrics_gc_queue_length_channel_consumer_deleted{name="rabbit@mars",type="disc"} 0
```