### PR TITLE
add alpine image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,6 @@
+FROM rabbitmq:3.7.8-management-alpine
+
+# Copy the plugin and its dependencies
+COPY "plugins/*.ez" "/opt/rabbitmq/plugins/"
+RUN chmod a+r /opt/rabbitmq/plugins/prometheus*.ez /opt/rabbitmq/plugins/accept*.ez \
+    && rabbitmq-plugins enable --offline prometheus_rabbitmq_exporter

--- a/Makefile
+++ b/Makefile
@@ -21,22 +21,29 @@ ERLANG_MK_COMMIT = rabbitmq-tmp
 include rabbitmq-components.mk
 include erlang.mk
 
-.PHONY: docker_build docker_push docker_latest docker_latest_pure
+.PHONY: docker_build docker_push docker_latest docker_pure docker_alpine
 
 docker_build:
 	docker build -t deadtrickster/rabbitmq_prometheus\:3.7.8 .
 	docker build -t deadtrickster/rabbitmq_prometheus\:latest .
 	docker build -t deadtrickster/rabbitmq_prometheus\:3.7.8-pure -f Dockerfile.pure  .
 	docker build -t deadtrickster/rabbitmq_prometheus\:latest-pure -f Dockerfile.pure  .
+	docker build -t deadtrickster/rabbitmq_prometheus\:3.7.8-alpine -f Dockerfile.alpine  .
+	docker build -t deadtrickster/rabbitmq_prometheus\:latest-alpine -f Dockerfile.alpine  .
 
 docker_push:
 	docker push deadtrickster/rabbitmq_prometheus\:3.7.8
 	docker push deadtrickster/rabbitmq_prometheus\:latest
 	docker push deadtrickster/rabbitmq_prometheus\:3.7.8-pure
 	docker push deadtrickster/rabbitmq_prometheus\:latest-pure
+	docker push deadtrickster/rabbitmq_prometheus\:3.7.8-alpine
+	docker push deadtrickster/rabbitmq_prometheus\:latest-alpine
 
 docker_latest:
 	-docker run -p15672\:15672 deadtrickster/rabbitmq_prometheus\:latest
 
 docker_pure:
 	-docker run -p15672\:15672 deadtrickster/rabbitmq_prometheus\:latest-pure
+
+docker_alpine:
+	-docker run -p15672\:15672 deadtrickster/rabbitmq_prometheus\:latest-alpine

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ You can rebuild the plugin yourself very easily - `clone https://github.com/dead
 ### Latest Docker:
  `docker run -p 8080:15672 deadtrickster/rabbitmq_prometheus`
 
+Alpine-based image is also available:
+ `docker run -p 8080:15672 deadtrickster/rabbitmq_prometheus:latest-alpine`
+
 ## Configuration
 
 This exporter supports the following options via `rabbitmq_exporter` entry of `prometheus` app env:


### PR DESCRIPTION
I've added alpine build. Alpine is used in [rabbitmq-ha](https://github.com/helm/charts/tree/master/stable/rabbitmq-ha) Helm chart.

Published alpine image will help to integrate the plugin into this Helm chart.