### PR TITLE
Add collector for core RabbitMQ metrics

### DIFF
--- a/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
+++ b/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
@@ -1,0 +1,237 @@
+-module(prometheus_rabbitmq_core_metrics_collector).
+-export([register/0,
+         register/1,
+         deregister_cleanup/1,
+         collect_mf/2,
+         collect_metrics/2]).
+
+-import(prometheus_model_helpers, [create_mf/4,
+                                   create_mf/5,
+                                   label_pairs/1,
+                                   gauge_metrics/1,
+                                   gauge_metric/1,
+                                   gauge_metric/2,
+                                   counter_metric/1,
+                                   counter_metric/2,
+                                   untyped_metric/1,
+                                   untyped_metric/2]).
+
+-include("prometheus_rabbitmq_exporter.hrl").
+-behaviour(prometheus_collector).
+
+-define(METRIC_NAME_PREFIX, "rabbitmq_core_").
+
+-define(METRICS,
+        [
+         {connection_coarse_metrics, [{2, connection_recv_oct, counter, "Count of octects received on the connection."},
+                                      {3, connection_send_oct, counter, "Count of octects sent on the connection."},
+                                      {4, connection_reductions, counter, "Count of reductions that take place on the queue process."}
+                                     ]},
+         {queue_coarse_metrics, [{2, queue_messages_ready, gauge, "Number of messages ready to be delivered to clients."},
+                                 {3, queue_messages_unacknowledge, gauge, "Number of messages delivered to clients but not yet acknowledged."},
+                                 {4, queue_messages, gauge, "Sum of ready and unacknowledged messages (queue depth)."},
+                                 {5, queue_reductions, counter, "Count of reductions that take place on the queue process."}
+                                ]},
+         {channel_exchange_metrics, [{2, channel_exchange_publish, gauge, "Count of messages published."},
+                                     {3, channel_exchange_confirm, gauge, "Count of messages confirmed."},
+                                     {4, channel_exchange_return_unroutable, gauge, "Count of messages returned to publisher as unroutable."}
+                                    ]},
+         {channel_process_metrics, [{2, channel_process_reductions, counter, "Count of reductions that take place on the channel process."}
+                                   ]},
+         {queue_metrics, [{2, queue_disk_reads, gauge, "Total number of times messages have been read from disk by this queue.", disk_reads},
+                          {2, queue_disk_writes, gauge, "Total number of times messages have been written to disk by this queue.", disk_writes}
+                         ]},
+         {node_persister_metrics,
+          [{2, node_io_read_count, counter, "Read operations since node start.", io_read_count},
+           {2, node_io_read_bytes, gauge, "Bytes read since node start.", io_read_bytes},
+           {2, node_io_read_time, gauge, "Total time of read operations.", io_read_time},
+           {2, node_io_write_count, counter, "Write operations since node start.", io_write_count},
+           {2, node_io_write_bytes, gauge, "Bytes written since node start.", io_write_bytes},
+           {2, node_io_write_time, gauge, "Total time of write operations.", io_write_time},
+           {2, node_io_sync_count, counter, "Sync operations since node start.", io_sync_count},
+           {2, node_io_sync_time, gauge, "Total time of sync operations.", io_sync_time},
+           {2, node_io_seek_count, counter, "Seek operations since node start.", io_seek_count},
+           {2, node_io_seek_time, gauge, "Total time of seek operations.", io_seek_time},
+           {2, node_io_reopen_count, counter, "Times files have been reopened by the file handle cache.", io_reopen_count},
+           {2, node_mnesia_ram_tx_count, counter, "Mnesia transactions in RAM since node start.",
+            mnesia_ram_tx_count},
+           {2, node_mnesia_disk_tx_count, counter, "Mnesia transactions in disk since node start.",
+            mnesia_disk_tx_count},
+           {2, node_msg_store_read_count, counter, "Read operations in the message store since node start.",
+            msg_store_read_count},
+           {2, node_msg_store_write_count, counter, "Write operations in the message store since node start.",
+            msg_store_write_count},
+           {2, queue_index_journal_write_count, counter, "Write operations in the queue index journal since node start.", queue_index_journal_write_count},
+           {2, queue_index_write_count, counter, "Queue index write operations since node start.", index_write_count},
+           {2, queue_index_read_count, counter, "Queue index read operations since node start.", index_read_count},
+           {2, queue_io_file_handle_open_attempt_count, counter, "File descriptor open attempts.",
+            io_file_handle_open_attempt_count},
+           {2, queue_io_file_handle_open_attempt_time, gauge, "Total time of file descriptor open attempts.",
+            io_file_handle_open_attempt_time}
+          ]},
+         {node_coarse_metrics,
+          [{2, node_fd_used, gauge, "File descriptors used.", fd_used},
+           {2, node_sockets_used, gauge, "Sockets used.", sockets_used},
+           {2, node_mem_used, gauge, "Memory used in bytes.", mem_used},
+           {2, node_disk_free, gauge, "Disk free in bytes.", disk_free},
+           {2, node_proc_used, gauge, "Erlang processes used.", proc_used},
+           {2, node_gc_num, counter, "GC runs.", gc_num},
+           {2, node_gc_bytes_reclaimed, counter, "Bytes reclaimed by GC.", gc_bytes_reclaimed},
+           {2, node_context_switches, counter, "Context switches since node start.", context_switches}
+          ]},
+         {connection_churn_metrics,
+          [{2, connection_created, counter, "Connections created."},
+           {3, connection_closed, counter, "Connections closed."},
+           {4, channel_created, counter, "Channels created."},
+           {5, channel_closed, counter, "Channels closed."},
+           {6, queue_declared, counter, "Queues declared."},
+           {7, queue_deleted, counter, "Queues deleted."}
+          ]},
+         {node_node_metrics,
+          [{2, node_node_send_bytes, counter, "Count of bytes sent to node.", send_bytes},
+           {2, node_node_recv_bytes, counter, "Count of bytes received from node.", recv_bytes}
+          ]},
+         {channel_queue_metrics,
+          [{2, channel_queue_get, counter, "Count of messages delivered in acknowledgement mode in response to basic.get.", get},
+           {2, channel_queue_get_no_ack, counter, "Count of messages delivered in no-acknowledgement mode in response to basic.get.", get_no_ack},
+           {2, channel_queue_deliver, counter, "Count of messages delivered in acknowledgement mode to consumers.", deliver},
+           {2, channel_queue_deliver_no_ack, counter, "Count of messages delivered in no-acknowledgement mode to consumers.", deliver_no_ack},
+           {2, channel_queue_redeliver, counter, "Count of subset of delivered messages which had the redelivered flag set.", redeliver},
+           {2, channel_queue_ack, counter, "Count of messages acknowledged.", ack},
+           {2, channel_queue_get_empty, counter, "Count of basic.get operations on empty queues.", get_empty}
+          ]},
+         {channel_metrics,
+          [{2, channel_consumer_count, gauge, "Consumers count.", consumer_count},
+           {2, channel_messages_unacknowledged, gauge, "Count of messages unacknowledged.", messages_unacknowledged},
+           {2, channel_messages_unconfirmed, gauge, "Count of messages unconfirmed.", messages_unconfirmed},
+           {2, channel_messages_uncommited, gauge, "Count of messages uncommited.", messages_uncommited},
+           {2, channel_messages_prefetch_count, gauge, "Limit to the number of unacknowledged messages on every connection on a channel.", prefetch_count},
+           {2, channel_messages_global_prefetch_count, gauge, "Global limit to the number of unacknowledged messages shared between all connections on a channel.", global_prefetch_count}
+          ]},
+         {connection_metrics,
+          [{2, connection_recv_count, counter, "Count of bytes received on the connection.", recv_count},
+           {2, connection_send_count, counter, "Count of bytes send on the connection.", send_count}
+          ]},
+         {node_metrics,
+          [{2, node_fd_total, gauge, "File descriptors available.", fd_total},
+           {2, node_sockets_total, gauge, "Sockets available.", sockets_total},
+           {2, node_mem_limit, gauge, "Memory usage high watermark.", mem_limit},
+           {2, node_disk_free_limit, gauge, "Free disk space low watermark.", disk_free_limit},
+           {2, node_proc_total, gauge, "Erlang processes limit.", proc_total},
+           {2, node_uptime, gauge, "Time in milliseconds since node start.", uptime},
+           {2, node_run_queue, gauge, "Runtime run queue.", run_queue},
+           {2, node_processors, gauge, "Logical processors.", processors},
+           {2, node_net_ticktime, gauge, "Periodic tick interval between all pairs of nodes to maintain the connections and to detect disconnections.", net_ticktime}
+          ]},
+         {channel_queue_exchange_metrics,
+          [{2, channel_queue_exchange_publish, counter, "Count of messages published."}
+          ]}
+        ]).
+
+-define(TOTALS, [
+                 {connection_created, connections, gauge, "RabbitMQ Connections count."},
+                 {channel_created, channels, gauge, "RabbitMQ Channels count."},
+                 {consumer_created, consumers, gauge, "RabbitMQ Consumers count."},
+                 {queue_metrics, queues, gauge, "RabbitMQ Queues count."}
+                ]).
+
+%%====================================================================
+%% Collector API
+%%====================================================================
+
+register() ->
+  register(default).
+
+register(Registry) ->
+  ok = prometheus_registry:register_collector(Registry, ?MODULE).
+
+deregister_cleanup(_) -> ok.
+
+collect_mf(_Registry, Callback) ->    
+    [begin
+         Data = ets:tab2list(Table),
+         mf(Callback, Contents, Data)
+     end || {Table, Contents} <- ?METRICS],
+    [begin
+         Size = ets:info(Table, size),
+         mf_totals(Callback, Name, Type, Help, Size)
+     end || {Table, Name, Type, Help} <- ?TOTALS],
+    ok.
+
+mf(Callback, Contents, Data) ->
+    [begin
+         Fun = fun(D) -> element(Index, D) end,
+         Callback(create_mf(?METRIC_NAME(Name), Help, catch_boolean(Type), ?MODULE,
+                            {Type, Fun, Data}))
+     end || {Index, Name, Type, Help} <- Contents],
+    [begin
+         Fun = fun(D) -> proplists:get_value(Key, element(Index, D)) end,
+         Callback(create_mf(?METRIC_NAME(Name), Help, catch_boolean(Type), ?MODULE,
+                            {Type, Fun, Data}))
+     end || {Index, Name, Type, Help, Key} <- Contents].
+
+mf_totals(Callback, Name, Type, Help, Size) ->
+    Callback(create_mf(?METRIC_NAME(Name), Help, catch_boolean(Type), Size)).
+
+collect_metrics(_, {Type, Fun, Items}) ->
+    [metric(Type, labels(Item), Fun(Item)) || Item <- Items].
+
+labels(Item) ->
+    label(element(1, Item)).
+
+label(#resource{virtual_host = VHost, kind = exchange, name = Name}) ->
+    [{vhost, VHost}, {exchange, Name}];
+label(#resource{virtual_host = VHost, kind = queue, name = Name}) ->
+    [{vhost, VHost}, {queue, Name}];
+label({P, {#resource{virtual_host = QVHost, kind = queue, name = QName},
+            #resource{virtual_host = EVHost, kind = exchange, name = EName}}}) when is_pid(P) ->
+    %% channel_queue_exchange_metrics {channel_id, {queue_id, exchange_id}}
+    [{channel, P}, {queue_vhost, QVHost}, {queue_name, QName},
+     {exchange_vhost, EVHost}, {exchange_name, EName}];
+label({I1, I2}) ->
+    label(I1) ++ label(I2);
+label(P) when is_pid(P) ->
+    [{channel, P}];
+label(A) when is_atom(A) ->
+    [{node, A}].
+
+metric(counter, Labels, Value) ->
+  emit_counter_metric_if_defined(Labels, Value);
+metric(gauge, Labels, Value) ->
+  emit_gauge_metric_if_defined(Labels, Value);
+metric(untyped, Labels, Value) ->
+  untyped_metric(Labels, Value);
+metric(boolean, Labels, Value0) ->
+  Value = case Value0 of
+            true -> 1;
+            false -> 0;
+            undefined -> undefined
+          end,
+  untyped_metric(Labels, Value).
+
+
+%%====================================================================
+%% Private Parts
+%%====================================================================
+catch_boolean(boolean) ->
+    untyped;
+     catch_boolean(T) ->
+         T.
+
+emit_counter_metric_if_defined(Labels, Value) ->
+  case Value of
+    undefined -> undefined;
+    '' ->
+      counter_metric(Labels, undefined);
+    Value ->
+      counter_metric(Labels, Value)
+  end.
+
+emit_gauge_metric_if_defined(Labels, Value) ->
+  case Value of
+    undefined -> undefined;
+    '' ->
+      gauge_metric(Labels, undefined);
+    Value ->
+      gauge_metric(Labels, Value)
+  end.


### PR DESCRIPTION
> This was done by @dcorbacho in https://github.com/dcorbacho/prometheus_rabbitmq_exporter/commit/db4762d1b23070df83ca8a5dc850eff359f46798, I'm just submitting the PR
> This is a follow-up from https://github.com/deadtrickster/prometheus_rabbitmq_exporter/issues/63

This collector puts the minimum amount of pressure on RabbitMQ since the
metrics are not aggregated. Metrics are read from ETS tables, they are
strictly node local, and the amount of data is minimal. We wouldn't even
need rabbitmq_management_agent for the majority of core metrics, meaning
that prometheus_rabbitmq_exporter wouldn't need to depend on
rabbitmq_management if it was configured to use just this collector.

The other benefit of core metrics is that they are constantly updated,
since every object writes metrics on its own interval (typically every
5s). When /api/metrics is requested, raw values from ETS are read &
returned - no aggregation, no delay. What you get for core metrics is
what happened at most 5s ago.

Our end-goal is to expose raw, per-node metrics. Cluster metrics are
just an aggregation of per-node metrics, which should be done in
Prometheus/Grafana, just-in-time. This would help visualise cluster
imbalances, such as a subset of nodes running hotter than others, as
well as off-load all metrics processing so that RabbitMQ can spend as
many reductions on message-related work. We are imagining the equivalent
of Linux's /proc subsystem, but for RabbitMQ + Erlang + Mnesia.

I would be very excited to enable a mode for this plugin that only
exposes node-local metrics and doesn't require rabbitmq_management. Is
that something that you would like to have a go at @deadtricker?

For completeness, I'm adding the metrics that this collector adds to the
/api/metrics output of a freshly booted node:

    # TYPE rabbitmq_core_connection_recv_oct counter
    # HELP rabbitmq_core_connection_recv_oct Count of octects received on the connection.
    # TYPE rabbitmq_core_connection_send_oct counter
    # HELP rabbitmq_core_connection_send_oct Count of octects sent on the connection.
    # TYPE rabbitmq_core_connection_reductions counter
    # HELP rabbitmq_core_connection_reductions Count of reductions that take place on the queue process.
    # TYPE rabbitmq_core_queue_messages_ready gauge
    # HELP rabbitmq_core_queue_messages_ready Number of messages ready to be delivered to clients.
    # TYPE rabbitmq_core_queue_messages_unacknowledge gauge
    # HELP rabbitmq_core_queue_messages_unacknowledge Number of messages delivered to clients but not yet acknowledged.
    # TYPE rabbitmq_core_queue_messages gauge
    # HELP rabbitmq_core_queue_messages Sum of ready and unacknowledged messages (queue depth).
    # TYPE rabbitmq_core_queue_reductions counter
    # HELP rabbitmq_core_queue_reductions Count of reductions that take place on the queue process.
    # TYPE rabbitmq_core_channel_exchange_publish gauge
    # HELP rabbitmq_core_channel_exchange_publish Count of messages published.
    # TYPE rabbitmq_core_channel_exchange_confirm gauge
    # HELP rabbitmq_core_channel_exchange_confirm Count of messages confirmed.
    # TYPE rabbitmq_core_channel_exchange_return_unroutable gauge
    # HELP rabbitmq_core_channel_exchange_return_unroutable Count of messages returned to publisher as unroutable.
    # TYPE rabbitmq_core_channel_process_reductions counter
    # HELP rabbitmq_core_channel_process_reductions Count of reductions that take place on the channel process.
    # TYPE rabbitmq_core_queue_disk_reads gauge
    # HELP rabbitmq_core_queue_disk_reads Total number of times messages have been read from disk by this queue.
    # TYPE rabbitmq_core_queue_disk_writes gauge
    # HELP rabbitmq_core_queue_disk_writes Total number of times messages have been written to disk by this queue.
    # TYPE rabbitmq_core_node_io_read_count counter
    # HELP rabbitmq_core_node_io_read_count Read operations since node start.
    rabbitmq_core_node_io_read_count{node="rabbit@08c5bed93480"} 1
    # TYPE rabbitmq_core_node_io_read_bytes gauge
    # HELP rabbitmq_core_node_io_read_bytes Bytes read since node start.
    rabbitmq_core_node_io_read_bytes{node="rabbit@08c5bed93480"} 1
    # TYPE rabbitmq_core_node_io_read_time gauge
    # HELP rabbitmq_core_node_io_read_time Total time of read operations.
    rabbitmq_core_node_io_read_time{node="rabbit@08c5bed93480"} 29
    # TYPE rabbitmq_core_node_io_write_count counter
    # HELP rabbitmq_core_node_io_write_count Write operations since node start.
    rabbitmq_core_node_io_write_count{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_node_io_write_bytes gauge
    # HELP rabbitmq_core_node_io_write_bytes Bytes written since node start.
    rabbitmq_core_node_io_write_bytes{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_node_io_write_time gauge
    # HELP rabbitmq_core_node_io_write_time Total time of write operations.
    rabbitmq_core_node_io_write_time{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_node_io_sync_count counter
    # HELP rabbitmq_core_node_io_sync_count Sync operations since node start.
    rabbitmq_core_node_io_sync_count{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_node_io_sync_time gauge
    # HELP rabbitmq_core_node_io_sync_time Total time of sync operations.
    rabbitmq_core_node_io_sync_time{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_node_io_seek_count counter
    # HELP rabbitmq_core_node_io_seek_count Seek operations since node start.
    rabbitmq_core_node_io_seek_count{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_node_io_seek_time gauge
    # HELP rabbitmq_core_node_io_seek_time Total time of seek operations.
    rabbitmq_core_node_io_seek_time{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_node_io_reopen_count counter
    # HELP rabbitmq_core_node_io_reopen_count Times files have been reopened by the file handle cache.
    rabbitmq_core_node_io_reopen_count{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_node_mnesia_ram_tx_count counter
    # HELP rabbitmq_core_node_mnesia_ram_tx_count Mnesia transactions in RAM since node start.
    rabbitmq_core_node_mnesia_ram_tx_count{node="rabbit@08c5bed93480"} 11
    # TYPE rabbitmq_core_node_mnesia_disk_tx_count counter
    # HELP rabbitmq_core_node_mnesia_disk_tx_count Mnesia transactions in disk since node start.
    rabbitmq_core_node_mnesia_disk_tx_count{node="rabbit@08c5bed93480"} 12
    # TYPE rabbitmq_core_node_msg_store_read_count counter
    # HELP rabbitmq_core_node_msg_store_read_count Read operations in the message store since node start.
    rabbitmq_core_node_msg_store_read_count{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_node_msg_store_write_count counter
    # HELP rabbitmq_core_node_msg_store_write_count Write operations in the message store since node start.
    rabbitmq_core_node_msg_store_write_count{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_queue_index_journal_write_count counter
    # HELP rabbitmq_core_queue_index_journal_write_count Write operations in the queue index journal since node start.
    rabbitmq_core_queue_index_journal_write_count{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_queue_index_write_count counter
    # HELP rabbitmq_core_queue_index_write_count Queue index write operations since node start.
    # TYPE rabbitmq_core_queue_index_read_count counter
    # HELP rabbitmq_core_queue_index_read_count Queue index read operations since node start.
    # TYPE rabbitmq_core_queue_io_file_handle_open_attempt_count counter
    # HELP rabbitmq_core_queue_io_file_handle_open_attempt_count File descriptor open attempts.
    rabbitmq_core_queue_io_file_handle_open_attempt_count{node="rabbit@08c5bed93480"} 10
    # TYPE rabbitmq_core_queue_io_file_handle_open_attempt_time gauge
    # HELP rabbitmq_core_queue_io_file_handle_open_attempt_time Total time of file descriptor open attempts.
    rabbitmq_core_queue_io_file_handle_open_attempt_time{node="rabbit@08c5bed93480"} 264
    # TYPE rabbitmq_core_node_fd_used gauge
    # HELP rabbitmq_core_node_fd_used File descriptors used.
    rabbitmq_core_node_fd_used{node="rabbit@08c5bed93480"} 81
    # TYPE rabbitmq_core_node_sockets_used gauge
    # HELP rabbitmq_core_node_sockets_used Sockets used.
    rabbitmq_core_node_sockets_used{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_node_mem_used gauge
    # HELP rabbitmq_core_node_mem_used Memory used in bytes.
    rabbitmq_core_node_mem_used{node="rabbit@08c5bed93480"} 97021952
    # TYPE rabbitmq_core_node_disk_free gauge
    # HELP rabbitmq_core_node_disk_free Disk free in bytes.
    rabbitmq_core_node_disk_free{node="rabbit@08c5bed93480"} 55178477568
    # TYPE rabbitmq_core_node_proc_used gauge
    # HELP rabbitmq_core_node_proc_used Erlang processes used.
    rabbitmq_core_node_proc_used{node="rabbit@08c5bed93480"} 399
    # TYPE rabbitmq_core_node_gc_num counter
    # HELP rabbitmq_core_node_gc_num GC runs.
    rabbitmq_core_node_gc_num{node="rabbit@08c5bed93480"} 5141
    # TYPE rabbitmq_core_node_gc_bytes_reclaimed counter
    # HELP rabbitmq_core_node_gc_bytes_reclaimed Bytes reclaimed by GC.
    rabbitmq_core_node_gc_bytes_reclaimed{node="rabbit@08c5bed93480"} 379204736
    # TYPE rabbitmq_core_node_context_switches counter
    # HELP rabbitmq_core_node_context_switches Context switches since node start.
    rabbitmq_core_node_context_switches{node="rabbit@08c5bed93480"} 190670
    # TYPE rabbitmq_core_connection_created counter
    # HELP rabbitmq_core_connection_created Connections created.
    rabbitmq_core_connection_created{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_connection_closed counter
    # HELP rabbitmq_core_connection_closed Connections closed.
    rabbitmq_core_connection_closed{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_channel_created counter
    # HELP rabbitmq_core_channel_created Channels created.
    rabbitmq_core_channel_created{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_channel_closed counter
    # HELP rabbitmq_core_channel_closed Channels closed.
    rabbitmq_core_channel_closed{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_queue_declared counter
    # HELP rabbitmq_core_queue_declared Queues declared.
    rabbitmq_core_queue_declared{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_queue_deleted counter
    # HELP rabbitmq_core_queue_deleted Queues deleted.
    rabbitmq_core_queue_deleted{node="rabbit@08c5bed93480"} 0
    # TYPE rabbitmq_core_node_node_send_bytes counter
    # HELP rabbitmq_core_node_node_send_bytes Count of bytes sent to node.
    # TYPE rabbitmq_core_node_node_recv_bytes counter
    # HELP rabbitmq_core_node_node_recv_bytes Count of bytes received from node.
    # TYPE rabbitmq_core_channel_queue_get counter
    # HELP rabbitmq_core_channel_queue_get Count of messages delivered in acknowledgement mode in response to basic.get.
    # TYPE rabbitmq_core_channel_queue_get_no_ack counter
    # HELP rabbitmq_core_channel_queue_get_no_ack Count of messages delivered in no-acknowledgement mode in response to basic.get.
    # TYPE rabbitmq_core_channel_queue_deliver counter
    # HELP rabbitmq_core_channel_queue_deliver Count of messages delivered in acknowledgement mode to consumers.
    # TYPE rabbitmq_core_channel_queue_deliver_no_ack counter
    # HELP rabbitmq_core_channel_queue_deliver_no_ack Count of messages delivered in no-acknowledgement mode to consumers.
    # TYPE rabbitmq_core_channel_queue_redeliver counter
    # HELP rabbitmq_core_channel_queue_redeliver Count of subset of delivered messages which had the redelivered flag set.
    # TYPE rabbitmq_core_channel_queue_ack counter
    # HELP rabbitmq_core_channel_queue_ack Count of messages acknowledged.
    # TYPE rabbitmq_core_channel_queue_get_empty counter
    # HELP rabbitmq_core_channel_queue_get_empty Count of basic.get operations on empty queues.
    # TYPE rabbitmq_core_channel_consumer_count gauge
    # HELP rabbitmq_core_channel_consumer_count Consumers count.
    # TYPE rabbitmq_core_channel_messages_unacknowledged gauge
    # HELP rabbitmq_core_channel_messages_unacknowledged Count of messages unacknowledged.
    # TYPE rabbitmq_core_channel_messages_unconfirmed gauge
    # HELP rabbitmq_core_channel_messages_unconfirmed Count of messages unconfirmed.
    # TYPE rabbitmq_core_channel_messages_uncommited gauge
    # HELP rabbitmq_core_channel_messages_uncommited Count of messages uncommited.
    # TYPE rabbitmq_core_channel_messages_prefetch_count gauge
    # HELP rabbitmq_core_channel_messages_prefetch_count Limit to the number of unacknowledged messages on every connection on a channel.
    # TYPE rabbitmq_core_channel_messages_global_prefetch_count gauge
    # HELP rabbitmq_core_channel_messages_global_prefetch_count Global limit to the number of unacknowledged messages shared between all connections on a channel.
    # TYPE rabbitmq_core_connection_recv_count counter
    # HELP rabbitmq_core_connection_recv_count Count of bytes received on the connection.
    # TYPE rabbitmq_core_connection_send_count counter
    # HELP rabbitmq_core_connection_send_count Count of bytes send on the connection.
    # TYPE rabbitmq_core_node_fd_total gauge
    # HELP rabbitmq_core_node_fd_total File descriptors available.
    rabbitmq_core_node_fd_total{node="rabbit@08c5bed93480"} 1048576
    # TYPE rabbitmq_core_node_sockets_total gauge
    # HELP rabbitmq_core_node_sockets_total Sockets available.
    rabbitmq_core_node_sockets_total{node="rabbit@08c5bed93480"} 943626
    # TYPE rabbitmq_core_node_mem_limit gauge
    # HELP rabbitmq_core_node_mem_limit Memory usage high watermark.
    rabbitmq_core_node_mem_limit{node="rabbit@08c5bed93480"} 13475676160
    # TYPE rabbitmq_core_node_disk_free_limit gauge
    # HELP rabbitmq_core_node_disk_free_limit Free disk space low watermark.
    rabbitmq_core_node_disk_free_limit{node="rabbit@08c5bed93480"} 50000000
    # TYPE rabbitmq_core_node_proc_total gauge
    # HELP rabbitmq_core_node_proc_total Erlang processes limit.
    rabbitmq_core_node_proc_total{node="rabbit@08c5bed93480"} 1048576
    # TYPE rabbitmq_core_node_uptime gauge
    # HELP rabbitmq_core_node_uptime Time in milliseconds since node start.
    rabbitmq_core_node_uptime{node="rabbit@08c5bed93480"} 24942
    # TYPE rabbitmq_core_node_run_queue gauge
    # HELP rabbitmq_core_node_run_queue Runtime run queue.
    rabbitmq_core_node_run_queue{node="rabbit@08c5bed93480"} 1
    # TYPE rabbitmq_core_node_processors gauge
    # HELP rabbitmq_core_node_processors Logical processors.
    rabbitmq_core_node_processors{node="rabbit@08c5bed93480"} 10
    # TYPE rabbitmq_core_node_net_ticktime gauge
    # HELP rabbitmq_core_node_net_ticktime Periodic tick interval between all pairs of nodes to maintain the connections and to detect disconnections.
    rabbitmq_core_node_net_ticktime{node="rabbit@08c5bed93480"} 60
    # TYPE rabbitmq_core_channel_queue_exchange_publish counter
    # HELP rabbitmq_core_channel_queue_exchange_publish Count of messages published.
    # TYPE rabbitmq_core_connections gauge
    # HELP rabbitmq_core_connections RabbitMQ Connections count.
    rabbitmq_core_connections 0
    # TYPE rabbitmq_core_channels gauge
    # HELP rabbitmq_core_channels RabbitMQ Channels count.
    rabbitmq_core_channels 0
    # TYPE rabbitmq_core_consumers gauge
    # HELP rabbitmq_core_consumers RabbitMQ Consumers count.
    rabbitmq_core_consumers 0
    # TYPE rabbitmq_core_queues gauge
    # HELP rabbitmq_core_queues RabbitMQ Queues count.