### PR TITLE
added flow to queue state case statement

### DIFF
--- a/src/collectors/prometheus_rabbitmq_queues_collector.erl
+++ b/src/collectors/prometheus_rabbitmq_queues_collector.erl
@@ -53,6 +53,7 @@
                          running -> 0;
                          undefined -> undefined;
                          down -> undefined;
+                         flow -> undefined;
                          {syncing, MsgCount} -> MsgCount
                        end
                    end}


### PR DESCRIPTION
Attempt to solve #100. I tried building locally to test it but was unable to. After installing MSYS2 on my Win10 laptop with necessary packages I got errors when running "make deps" (see example below)

Crash dump is being written to: erl_crash.dump...done
make[2]: Entering directory '/c/temp/prometheus_rabbitmq_exporter/deps/rabbitmq_codegen'
make[2]: Leaving directory '/c/temp/prometheus_rabbitmq_exporter/deps/rabbitmq_codegen'
Error: No Makefile to build dependency /c/temp/prometheus_rabbitmq_exporter/deps/lager.
make[1]: *** [erlang.mk:4512: deps] Error 2
make[1]: Leaving directory '/c/temp/prometheus_rabbitmq_exporter/deps/rabbit_common'
make: *** [erlang.mk:4314: deps] Error 2

And the partial contents of erl_crash.dump:
=erl_crash_dump:0.5
Mon Jul 13 15:10:02 2020
Slogan: init terminating in do_boot ({undef,[{rmemo,start,[],[]},{erl_eval,do_apply,6,[{_},{_}]},{erl_eval,exprs,5,[{_},{_}]},{init,start_it,1,[{_},{_}]},{init,start_em,1,[{_},{_}]},{init,do_boot,3,[{_},{_}]}
System version: Erlang/OTP 23 [erts-11.0.1] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1]
Compiled: Wed May 20 14:04:00 2020

I also tried the same with an older version or Erlang (10.2) with same/similar error.

PS: It would be nice to have a section somewhere explaining how to build it.